### PR TITLE
[config] Fix getConfigFile dirname issue

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -11,7 +11,6 @@
         }
       }
     ],
-    "module-extension-resolver",
-    "babel-plugin-transform-import-meta"
+    "module-extension-resolver"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitove",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "description": "An interactive git cli tool for consistant commit messages.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@typescript-eslint/parser": "^6.3.0",
     "babel-plugin-module-extension-resolver": "^1.0.0",
     "babel-plugin-module-resolver": "^5.0.0",
-    "babel-plugin-transform-import-meta": "^2.2.1",
     "eslint": "^8.46.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,9 +61,6 @@ devDependencies:
   babel-plugin-module-resolver:
     specifier: ^5.0.0
     version: 5.0.0
-  babel-plugin-transform-import-meta:
-    specifier: ^2.2.1
-    version: 2.2.1(@babel/core@7.22.10)
   eslint:
     specifier: ^8.46.0
     version: 8.46.0
@@ -1438,16 +1435,6 @@ packages:
       pkg-up: 3.1.0
       reselect: 4.1.8
       resolve: 1.22.4
-    dev: true
-
-  /babel-plugin-transform-import-meta@2.2.1(@babel/core@7.22.10):
-    resolution: {integrity: sha512-AxNh27Pcg8Kt112RGa3Vod2QS2YXKKJ6+nSvRtv7qQTJAdx0MZa4UHZ4lnxHUWA2MNbLuZQv5FVab4P1CoLOWw==}
-    peerDependencies:
-      '@babel/core': ^7.10.0
-    dependencies:
-      '@babel/core': 7.22.10
-      '@babel/template': 7.22.5
-      tslib: 2.6.1
     dev: true
 
   /babel-preset-current-node-syntax@1.0.1(@babel/core@7.22.10):

--- a/src/config/getConfigfile.ts
+++ b/src/config/getConfigfile.ts
@@ -3,9 +3,9 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { DEFAULT_CONFIG } from 'src/config/defaultConfig';
 
-const dirname = fileURLToPath(new URL('.', import.meta.url));
-const test = path.resolve(dirname, '../..');
-const dirpath = path.join(test, 'gitoverc.json');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const test = path.resolve(__dirname, '../..');
+const dirpath = path.join(test, '.gitoverc.json');
 
 const readUserConfigFile = () => {
   const readfile: Configuration = JSON.parse(readFileSync(dirpath, { encoding: 'utf-8', flag: 'r' }));

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,3 @@
 export * from './defaultConfig';
-// export * from './getConfigfile';
-// export * from './getValueFromConfig';
+export * from './getConfigfile';
+export * from './getValueFromConfig';


### PR DESCRIPTION
<!--
    Create PR with title like "[(subject)] (description)".

    subjects: commit, rebase, push, etc.
-->

## Issue or reason for change
- #57 

## Description of changes
- have been using `babel-plugin-transform-import-meta` in babel plugin.
- this plugin converts `import.meta` into CJS compatible code.

### before
- babel.config.json
```json
{
  "presets": [
    "@babel/preset-typescript"
  ],
  "plugins": [
    [
      "module-resolver",
      {
        "alias": {
          "src": "./gen"
        }
      }
    ],
    "module-extension-resolver",
    "babel-plugin-transform-import-meta"
  ]
}
```
- getConfigFile.ts
```ts
const __dirname = path.dirname(fileURLToPath(import.meta.url));
const __dirname = fileURLToPath(new URL('.', require('url').pathToFileURL(__filename).toString()));
```

### after
- babel.config.json
```json
{
  "presets": [
    "@babel/preset-typescript"
  ],
  "plugins": [
    [
      "module-resolver",
      {
        "alias": {
          "src": "./gen"
        }
      }
    ],
    "module-extension-resolver"
  ]
}
```
- getConfigFile.ts
```ts
const __dirname = path.dirname(fileURLToPath(import.meta.url));
const __dirname = path.dirname(fileURLToPath(import.meta.url));
```

## Related issues and links
- closes #57 
